### PR TITLE
Swap livetex for texlive

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ coming soon… thus with [brew]:
 brew install pandoc librsvg pandoc-crossref basictex
 
 # linuxbrew/WSL
-brew install pandoc librsvg pandoc-crossref livetex
+brew install pandoc librsvg pandoc-crossref texlive
 ```
 
 Then:


### PR DESCRIPTION
The README had "livetex" when it should've had "texlive". After making this change, the instructions work as-is. 
See #44.
