### PR TITLE
Georgia supports cyrillic (and hopefully more) characters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - metadata.yml
       - img/*
       - .github/workflows/ci.yml
+      - Makefile
 
 concurrency:
   group: ${{ github.ref }}
@@ -20,14 +21,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: .github/mk-pantry-accessible.sh ${{ secrets.TEMP_JACOBS_GITHUB_PAT }}
-      - run: sudo apt-get install texlive texlive-latex-extra #FIXME
-      - uses: teaxyz/setup@v0
+      # - run: .github/mk-pantry-accessible.sh ${{ secrets.TEMP_JACOBS_GITHUB_PAT }}
+      - run: | # Use on-box make until tea/pantry revlock is resolved
+          sudo apt-get install \
+            texlive-latex-base \
+            texlive-fonts-recommended \
+            texlive-fonts-extra
+          brew install \
+            pandoc \
+            pandoc-crossref \
+            librsvg
+      - run: |
+          # Need a standard font, and ttf-mscorefonts-installer has a EULA dialog. Definitely #FIXME
+          echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
+          sudo apt-get install texlive texlive-latex-extra texlive-xetex msttcorefonts #FIXME
+      # - uses: teaxyz/setup@v0
       - name: Set Version
         run: |
           date=$(date '+%Y%m%d')
           echo "- \fancyfoot[L]{$VERSION+$date}" >> metadata.yml
-      - run: tea make
+      # - run: tea make
+      - run: make  # Use on-box make until tea/pantry revlock is resolved
       - uses: actions/upload-artifact@v3
         with:
           name: tea.white-paper

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,14 +36,27 @@ jobs:
     needs: [check]
     steps:
       - uses: actions/checkout@v3
-      - run: .github/mk-pantry-accessible.sh ${{ secrets.TEMP_JACOBS_GITHUB_PAT }}
-      - run: sudo apt-get install texlive texlive-latex-extra #FIXME
-      - uses: teaxyz/setup@v0
+      # - run: .github/mk-pantry-accessible.sh ${{ secrets.TEMP_JACOBS_GITHUB_PAT }}
+      - run: | # Use on-box make until tea/pantry revlock is resolved
+          sudo apt-get install \
+            texlive-latex-base \
+            texlive-fonts-recommended \
+            texlive-fonts-extra
+          brew install \
+            pandoc \
+            pandoc-crossref \
+            librsvg
+      - run: |
+          # Need a standard font, and ttf-mscorefonts-installer has a EULA dialog. Definitely #FIXME
+          echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
+          sudo apt-get install texlive texlive-latex-extra texlive-xetex msttcorefonts #FIXME
+      # - uses: teaxyz/setup@v0
       - name: Set Version
         run: |
           date=$(date '+%Y%m%d')
           echo "- \fancyfoot[L]{$VERSION}" >> metadata.yml
-      - run: tea make
+      # - run: tea make
+      - run: make  # Use on-box make until tea/pantry revlock is resolved
       - uses: actions/upload-artifact@v3
         with:
           name: tea.white-paper

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ tea.white-paper_%.pdf: i18n/%/white-paper.md i18n/%/metadata.yml tea.csl img/*
 	--filter pandoc-crossref \
 	--csl=tea.csl \
 	--citeproc \
+	--pdf-engine=xelatex \
+	--variable mainfont="Georgia" \
 	$<
 
 clean:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Source these yourself or use tea: `sh <(curl tea.xyz)`.
 | pandoc.org          | ^2.18   |
 | pandoc.org/crossref | ^0.3    |
 | gnome.org/librsvg   | ^2.54   |
+| gnu.org/make        | ^4      |
 
 
 ## Translate


### PR DESCRIPTION
- uses xelatex and Georgia font for translations (for extended charset support)
- reverts to non-tea build while we sort out pre-release revlock issues ([x] ~@mxcl blessing required~)
- adds `gnu.org/make` dep
- builds on change to `Makefile`

resolves #73 