### PR TITLE
Push translations without release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,16 @@
+name: CD
+
+on:
+  push:
+    branches: [main]
+    paths: ['i18n/**']
+
+env:
+  TEA_SECRET: ${{ secrets.TEA_SECRET }}
+
+jobs:
+  cd:
+    uses: ./.github/workflows/make.yml
+    with:
+      upload: true
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,40 +14,7 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  TEA_SECRET: ${{ secrets.TEA_SECRET }}
-
 jobs:
   compile:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - run: | # Use on-box make until tea/pantry revlock is resolved
-          sudo apt-get install \
-            texlive-latex-base \
-            texlive-fonts-recommended \
-            texlive-fonts-extra
-          brew install \
-            pandoc \
-            pandoc-crossref \
-            librsvg
-          #FIXME: Can't pass secrets to remote-branch CI, so this is until teaxyz/pantry is public
-          sed -ne 's/^# tea\/white-paper \([0-9]*\.[0-9]*\.[0-9]*\)/VERSION=\1/p' README.md >> $GITHUB_ENV
-      - run: |
-          # Need a standard font, and ttf-mscorefonts-installer has a EULA dialog. Definitely #FIXME
-          echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-          sudo apt-get install texlive texlive-latex-extra texlive-xetex msttcorefonts #FIXME
-      # - run: .github/mk-pantry-accessible.sh ${{ secrets.TEMP_JACOBS_GITHUB_PAT }}
-      # - uses: teaxyz/setup@v0
-      - name: Set Version
-        run: |
-          date=$(date '+%Y%m%d')
-          echo "- \fancyfoot[L]{$VERSION+$date}" >> metadata.yml
-      # - run: tea make
-      - run: make  # Use on-box make until tea/pantry revlock is resolved
-      - uses: actions/upload-artifact@v3
-        with:
-          name: tea.white-paper
-          path: |
-            tea.white-paper.pdf
-            tea.white-paper_??.pdf
+    uses: ./.github/workflows/make.yml
+    secrets: inherit

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,0 +1,89 @@
+name: make
+
+on:
+  workflow_call:
+    inputs:
+      release:
+        default: false
+        required: false
+        type: boolean
+      upload:
+        default: false
+        required: false
+        type: boolean
+
+env:
+  TEA_SECRET: ${{ secrets.TEA_SECRET }}
+
+jobs:
+  make:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: | # Use on-box make until tea/pantry revlock is resolved
+        sudo apt-get install \
+          texlive-latex-base \
+          texlive-fonts-recommended \
+          texlive-fonts-extra
+        brew install \
+          pandoc \
+          pandoc-crossref \
+          librsvg
+        #FIXME: Can't pass secrets to remote-branch CI, so this is until teaxyz/pantry is public
+        sed -ne 's/^# tea\/white-paper \([0-9]*\.[0-9]*\.[0-9]*\)/VERSION=\1/p' README.md >> $GITHUB_ENV
+    - run: |
+        # Need a standard font, and ttf-mscorefonts-installer has a EULA dialog. Definitely #FIXME
+        echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
+        sudo apt-get install texlive texlive-latex-extra texlive-xetex msttcorefonts #FIXME
+    # - run: .github/mk-pantry-accessible.sh ${{ secrets.TEMP_JACOBS_GITHUB_PAT }}
+    # - uses: teaxyz/setup@v0
+
+    - name: Set Version - Release
+      if: ${{ inputs.release }}
+      run: echo "- \fancyfoot[L]{$VERSION}" >> metadata.yml
+    - name: Set Version - CI/CD
+      if: ${{ !inputs.release }}
+      run: |
+        date=$(date '+%Y%m%d')
+        echo "- \fancyfoot[L]{$VERSION+$date}" >> metadata.yml
+
+    # - run: tea make
+    - run: make  # Use on-box make until tea/pantry revlock is resolved
+    - uses: actions/upload-artifact@v3
+      with:
+        name: tea.white-paper
+        path: |
+          tea.white-paper.pdf
+          tea.white-paper_??.pdf
+
+    # Following steps only run for upload: true
+    - name: AWS credentials
+      if: ${{ inputs.upload }}
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+
+    - name: Bundle translations
+      if: ${{ inputs.upload }}
+      run: |
+        mkdir white-papers
+        cp tea.white-paper_??.pdf white-papers/
+    - name: Bundle release
+      if: ${{ inputs.upload && inputs.release }}
+      run: cp tea.white-paper.pdf white-papers/
+
+    - name: Upload to S3
+      if: ${{ inputs.upload }}
+      run: |
+        aws s3 sync \
+          ./white-papers s3://www.tea.xyz/ \
+          --metadata-directive REPLACE \
+          --cache-control no-cache,must-revalidate
+    - name: Invalidate cache
+      if: ${{ inputs.upload }}
+      run: |
+        aws cloudfront create-invalidation \
+          --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} \
+          --paths / /tea.white-paper*.pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,37 +31,18 @@ jobs:
       - uses: andymckay/cancel-action@0.2
         if: ${{ steps.rev-parse.outputs.result == 'cancel' }}
 
+  make:
+    needs: [check]
+    uses: ./.github/workflows/make.yml
+    with:
+      release: true
+      upload: true
+    secrets: inherit
+
   release:
     runs-on: ubuntu-latest
-    needs: [check]
+    needs: [make]
     steps:
-      - uses: actions/checkout@v3
-      - run: .github/mk-pantry-accessible.sh ${{ secrets.TEMP_JACOBS_GITHUB_PAT }}
-      - uses: teaxyz/setup@v0
-      - run: | # Use on-box make until tea/pantry revlock is resolved
-          sudo apt-get install \
-            texlive-latex-base \
-            texlive-fonts-recommended \
-            texlive-fonts-extra
-          brew install \
-            pandoc \
-            pandoc-crossref \
-            librsvg
-      - run: |
-          # Need a standard font, and ttf-mscorefonts-installer has a EULA dialog. Definitely #FIXME
-          echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-          sudo apt-get install texlive texlive-latex-extra texlive-xetex msttcorefonts #FIXME
-      - name: Set Version
-        run: echo "- \fancyfoot[L]{$VERSION}" >> metadata.yml
-      # - run: tea make
-      - run: make  # Use on-box make until tea/pantry revlock is resolved
-      - uses: actions/upload-artifact@v3
-        with:
-          name: tea.white-paper
-          path: |
-            tea.white-paper.pdf
-            tea.white-paper_??.pdf
-
       - name: Tag Release
         uses: rickstaa/action-create-tag@v1
         with:
@@ -73,23 +54,3 @@ jobs:
           files: |
             tea.white-paper.pdf
             tea.white-paper_??.pdf
-
-      - name: AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      - name: Upload to S3
-        run: |
-          mkdir white-papers
-          cp tea.white-paper.pdf tea.white-paper_??.pdf white-papers/
-          aws s3 sync \
-            ./white-papers s3://www.tea.xyz/ \
-            --metadata-directive REPLACE \
-            --cache-control no-cache,must-revalidate
-      - name: Invalidate cache
-        run: |
-          aws cloudfront create-invalidation \
-            --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }} \
-            --paths / /tea.white-paper*.pdf


### PR DESCRIPTION
- [x] factors all build logic into a common workflow
- [x] uses boolean inputs to differentiate between CI/CD/release
- [x] CD deploys translations on merge, without requiring a release