### PR TITLE
Update token allocation figure's background

### DIFF
--- a/white-paper.md
+++ b/white-paper.md
@@ -285,7 +285,7 @@ TEA tokens will also be utilized to support packages and secure the software sup
 
 It’s recommended that a 10 billion maximum token supply be distributed across all members of the tea community as described below:
 
-<figure><img src=".gitbook/assets/Token Allocation-Updated.svg" alt=""><figcaption><p>Figure 3 - Token distribution of maximum supply</p></figcaption></figure>
+<figure><img src=".gitbook/assets/Token Allocation-Updated.svg"{: style="background-color: white;"} alt=""><figcaption><p>Figure 3 - Token distribution of maximum supply</p></figcaption></figure>
 
 Roughly 51.4% of the maximum token supply should be allocated to “Ecosystem & Governance”, which includes incentives for open-source projects to onboard and maintain their codebase as well as rewards for contributing to decentralized votes and consensus via the tea DAO. Tokens allocated to “Ecosystem & Governance” should be distributed as Proof of Contribution rewards, staking rewards, and other types of developer-centric incentives.
 


### PR DESCRIPTION
Details in the `Token Allocation-Updated.svg` figure was not showing properly in the website and GitHub repository because the background color and text color was the same. I changed the background color to white. So, it shows everything in the figure right now.